### PR TITLE
Convert endianess on big endian systems.

### DIFF
--- a/main.c
+++ b/main.c
@@ -172,11 +172,13 @@ int main(
 			i = 0;
 			while ( devQuery.mem[ i ].Type != TypeEndOfTypeList ) i++;
 			devQuery.memBlocks = i;
-			for ( i = 0; i < devQuery.memBlocks; i++ )
+			for ( i = 0; i < devQuery.memBlocks; i++ ) {
+			  devQuery.mem[i].Address = convertEndian(devQuery.mem[i].Address);
+			  devQuery.mem[i].Length = convertEndian(devQuery.mem[i].Length);
 			  if(devQuery.mem[i].Type == TypeProgramMemory) {
 			    (void)printf(": %d bytes free\n",devQuery.mem[i].Length);
-			    break;
 			    }
+			}
 
 			(void)printf("Device family: ");
  			switch (devQuery.DeviceFamily)

--- a/mphidflash.h
+++ b/mphidflash.h
@@ -59,6 +59,13 @@
                                 (usbBuf[pos + 3] << 24) )
 #endif /* i386 || __x86_64__ */
 
+/* Helper function to convert to correct endianess */
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define convertEndian(x) __builtin_bswap32(x)
+#else
+#define convertEndian(x) x
+#endif  // Big endian
+
 /* Values derived from Microchip HID Bootloader source */
 
 /* Bootloader commands */


### PR DESCRIPTION
The usb data is returned as little endian. When using on big endian
systems (such as mips) this must be converted.