### PR TITLE
Use strip from the toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CC       = gcc
 OBJS     = main.o hex.o
 EXECPATH = binaries
 DISTPATH = dist
+STRIP   := strip
 
 ifeq ($(shell uname -s),Darwin)
 # Rules for Mac OS X

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ mphidflash32: mphidflash
 
 mphidflash: $(OBJS)
 	$(CC) $(OBJS) $(LDFLAGS) -o $(EXECPATH)/$(EXEC)
-	strip $(EXECPATH)/$(EXEC)
+	$(STRIP) $(EXECPATH)/$(EXEC)
 
 install:
 	@echo


### PR DESCRIPTION
Strip binaries using the strip tool set by the current toolchain and not
the hardcoded system one. This fix is needed for crosscompilation.